### PR TITLE
Add manifests for running hue-exporter in k8s/k3s

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,44 @@ There are a few docker images built, including ones for ARM7 (Raspberry Pi). You
 docker run -p 9366:9366 -v my_config.yml:/etc/hue_exporter/config.yml mitchellrj/hue_exporter:latest
 ```
 
+### Kubernetes
+
+The manifests directory includes a Deployment, a Service, a ServiceMonitor, and a ConfigMap.
+The config for the hue bridge (IP address and user token) are stored in the config map.
+
+The manifests assume you have prometheus deployed in `monitoring` namespace and are deployed in the same namespace. In
+case you prometheus is running in a different namespace, change the namespace of the manifests too to match the namespace.
+Prometheus `ServiceMonitorSelector` config needs to be able to match to the ServiceMonitor labels.
+
+e.g. in this case the serviceMonitorSelector is matching the name key in labels of the ServiceMonitor.
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  ...
+  serviceMonitorSelector:
+    matchExpressions:
+    - key: name
+      operator: In
+      values:
+      - hue-exporter
+      - kube-state-metrics
+      - node-exporter
+      - kubelet
+  ...
+
+```
+
+There are two sets of manifests: one for arm7 and one for amd64. The
+only difference between the two manifests is the image tag in the deployment.yaml.
+
+- For amd64 cluster: `kubectl apply -f manifests/amd64`
+- For arm7 cluster: `kubectl apply -f manifests/arm7`
+
+
 ## License
 
 MIT / X11 Consortium license. I'd prefer to use Apache 2.0, but the excellent Hue library that this app uses is GPL 2.0 and that isn't compatible with Apache.

--- a/manifests/amd64/configmap.yaml
+++ b/manifests/amd64/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hue-exporter-config
+  namespace: monitoring
+data:
+  config.yml: |
+    ip_address: 192.168.1.2
+    api_key: "PCZtdsLqGSNaPYUX7SBedriXkud322UZZk3TsJf9"
+    sensors:
+      match_names: true
+      ignore_types:
+      - CLIPGenericStatus

--- a/manifests/amd64/deployment.yaml
+++ b/manifests/amd64/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hue-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: hue-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hue-exporter
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hue-exporter
+    spec:
+      containers:
+        - name: hue-exporter
+          image: mitchellrj/hue_exporter:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: metrics
+              containerPort: 9366
+              protocol: TCP
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/hue_exporter/config.yml
+              subPath: config.yml
+      volumes:
+        - name: config-volume
+          configMap:
+            name: hue-exporter-config

--- a/manifests/amd64/service-monitor.yaml
+++ b/manifests/amd64/service-monitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: hue-exporter
+    name: hue-exporter
+  name: hue-exporter
+  namespace: monitoring
+spec:
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hue-exporter
+  namespaceSelector:
+    matchNames:
+      - monitoring
+  endpoints:
+    - port: metrics

--- a/manifests/amd64/service.yaml
+++ b/manifests/amd64/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: hue-exporter
+  name: hue-exporter
+  namespace: monitoring
+spec:
+  ports:
+    - name: metrics
+      port: 9366
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: hue-exporter

--- a/manifests/arm7/configmap.yaml
+++ b/manifests/arm7/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hue-exporter-config
+  namespace: monitoring
+data:
+  config.yml: |
+    ip_address: 192.168.1.2
+    api_key: "PCZtdsLqGSNaPYUX7SBedriXkud322UZZk3TsJf9"
+    sensors:
+      match_names: true
+      ignore_types:
+      - CLIPGenericStatus

--- a/manifests/arm7/deployment.yaml
+++ b/manifests/arm7/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hue-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: hue-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hue-exporter
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hue-exporter
+    spec:
+      containers:
+        - name: hue-exporter
+          image: mitchellrj/hue_exporter:latest-arm7
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: metrics
+              containerPort: 9366
+              protocol: TCP
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/hue_exporter/config.yml
+              subPath: config.yml
+      volumes:
+        - name: config-volume
+          configMap:
+            name: hue-exporter-config

--- a/manifests/arm7/service-monitor.yaml
+++ b/manifests/arm7/service-monitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: hue-exporter
+    name: hue-exporter
+  name: hue-exporter
+  namespace: monitoring
+spec:
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hue-exporter
+  namespaceSelector:
+    matchNames:
+      - monitoring
+  endpoints:
+    - port: metrics

--- a/manifests/arm7/service.yaml
+++ b/manifests/arm7/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: hue-exporter
+  name: hue-exporter
+  namespace: monitoring
+spec:
+  ports:
+    - name: metrics
+      port: 9366
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: hue-exporter


### PR DESCRIPTION
Add manifests and update README with instructions on how to use the
manifests and wire exporter with the Prometheus deployment in a Kubernetes cluster.