### PR TITLE
Add build phase to dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 Dockerfile*
 *.md
-Gopkg.*
 hue_exporter
 LICENSE
 Makefile

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,9 +1,34 @@
-FROM        alpine:latest
+# Build stage
+FROM golang:1.12 AS builder
 MAINTAINER  Richard Mitchell <hue-exporter@mitch.org.uk>
 
-COPY ./.build/linux-amd64/hue_exporter /bin/hue_exporter
-COPY hue_exporter.example.yml   /etc/hue_exporter/config.yml
+WORKDIR /go/src/github.com/mitchellrj/hue_exporter
 
-EXPOSE      9366
-ENTRYPOINT  [ "/bin/hue_exporter" ]
-CMD         [ "--config.file=/etc/hue_exporter/config.yml" ]
+# Install dep
+RUN curl -fsSL -o /usr/local/bin/dep https://github.com/golang/dep/releases/download/v0.5.4/dep-linux-amd64 && \
+    chmod +x /usr/local/bin/dep
+
+# Copy dependency files first
+COPY Gopkg.toml Gopkg.lock ./
+
+# Install dependencies
+RUN dep ensure -vendor-only
+
+# Copy the rest of the source code
+COPY . .
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build -a -tags 'netgo static_build' \
+    -ldflags '-s -w -extldflags "-static"' \
+    -o .build/linux-amd64/hue_exporter
+
+# Final stage
+FROM alpine:latest
+
+COPY --from=builder /go/src/github.com/mitchellrj/hue_exporter/.build/linux-amd64/hue_exporter /bin/hue_exporter
+COPY hue_exporter.example.yml /etc/hue_exporter/config.yml
+
+EXPOSE 9366
+ENTRYPOINT [ "/bin/hue_exporter" ]
+CMD [ "--config.file=/etc/hue_exporter/config.yml" ]

--- a/Dockerfile.arm7
+++ b/Dockerfile.arm7
@@ -1,9 +1,34 @@
-FROM        armhf/alpine:latest
+# Build stage
+FROM golang:1.12 AS builder
 MAINTAINER  Richard Mitchell <hue-exporter@mitch.org.uk>
 
-COPY ./.build/linux-armv7/hue_exporter /bin/hue_exporter
-COPY hue_exporter.example.yml   /etc/hue_exporter/config.yml
+WORKDIR /go/src/github.com/mitchellrj/hue_exporter
 
-EXPOSE      9366
-ENTRYPOINT  [ "/bin/hue_exporter" ]
-CMD         [ "--config.file=/etc/hue_exporter/config.yml" ]
+# Install dep
+RUN curl -fsSL -o /usr/local/bin/dep https://github.com/golang/dep/releases/download/v0.5.4/dep-linux-amd64 && \
+    chmod +x /usr/local/bin/dep
+
+# Copy dependency files first
+COPY Gopkg.toml Gopkg.lock ./
+
+# Install dependencies
+RUN dep ensure -vendor-only
+
+# Copy the rest of the source code
+COPY . .
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 \
+    go build -a -tags 'netgo static_build' \
+    -ldflags '-s -w -extldflags "-static"' \
+    -o .build/linux-armv7/hue_exporter
+
+# Final stage
+FROM alpine:latest
+
+COPY --from=builder /go/src/github.com/mitchellrj/hue_exporter/.build/linux-armv7/hue_exporter /bin/hue_exporter
+COPY hue_exporter.example.yml /etc/hue_exporter/config.yml
+
+EXPOSE 9366
+ENTRYPOINT [ "/bin/hue_exporter" ]
+CMD [ "--config.file=/etc/hue_exporter/config.yml" ]


### PR DESCRIPTION
Before this commit, you had to install tools like `go` and `dep` locally, build it and then copy it into docker.
After this commit, there is a separate docker build stage, which performs the build step as part of docker, but isn't part of the final image to reduce resulting image size.

I've also updated the arm build to be based directly on `alpine:latest`, since this has now arm builds available natively.